### PR TITLE
Exposed textStyle param of StoryItem.text

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -156,10 +156,15 @@ class _MoreStoriesState extends State<MoreStories> {
           StoryItem.text(
             title: "I guess you'd love to see more of our food. That's great.",
             backgroundColor: Colors.blue,
+            
           ),
           StoryItem.text(
             title: "Nice!\n\nTap to continue.",
             backgroundColor: Colors.red,
+            textStyle: TextStyle(
+              fontFamily: 'Dancing',
+              fontSize: 40,
+            ),
           ),
           StoryItem.pageImage(
             url:

--- a/lib/widgets/story_view.dart
+++ b/lib/widgets/story_view.dart
@@ -52,6 +52,7 @@ class StoryItem {
   static StoryItem text({
     @required String title,
     @required Color backgroundColor,
+    TextStyle textStyle,
     bool shown = false,
     double fontSize = 18,
     bool roundedTop = false,
@@ -84,10 +85,13 @@ class StoryItem {
         child: Center(
           child: Text(
             title,
-            style: TextStyle(
-              color: contrast > 1.8 ? Colors.white : Colors.black,
-              fontSize: fontSize,
-            ),
+            style: textStyle?.copyWith(
+                  color: contrast > 1.8 ? Colors.white : Colors.black,
+                ) ??
+                TextStyle(
+                  color: contrast > 1.8 ? Colors.white : Colors.black,
+                  fontSize: fontSize,
+                ),
             textAlign: TextAlign.center,
           ),
         ),

--- a/lib/widgets/story_view.dart
+++ b/lib/widgets/story_view.dart
@@ -89,6 +89,7 @@ class StoryItem {
                 ) ??
                 TextStyle(
                   color: contrast > 1.8 ? Colors.white : Colors.black,
+                  fontSize: 18,
                 ),
             textAlign: TextAlign.center,
           ),

--- a/lib/widgets/story_view.dart
+++ b/lib/widgets/story_view.dart
@@ -54,7 +54,6 @@ class StoryItem {
     @required Color backgroundColor,
     TextStyle textStyle,
     bool shown = false,
-    double fontSize = 18,
     bool roundedTop = false,
     bool roundedBottom = false,
     Duration duration,
@@ -90,7 +89,6 @@ class StoryItem {
                 ) ??
                 TextStyle(
                   color: contrast > 1.8 ? Colors.white : Colors.black,
-                  fontSize: fontSize,
                 ),
             textAlign: TextAlign.center,
           ),


### PR DESCRIPTION
This PR exposes the `textStyle` param of the `title` provided to the `StoryItem.text` to allow customization of font size, font family, etc.
Closes #45 