### PR TITLE
Fix Issue #56 - support of streaming HLS urls in storyVideo widget

### DIFF
--- a/lib/widgets/story_video.dart
+++ b/lib/widgets/story_video.dart
@@ -43,18 +43,21 @@ class VideoLoader {
 class StoryVideo extends StatefulWidget {
   final StoryController storyController;
   final VideoLoader videoLoader;
+  final bool isHLS;
 
-  StoryVideo(this.videoLoader, {this.storyController, Key key})
+  StoryVideo(this.videoLoader, {this.storyController, this.isHLS = false, Key key})
       : super(key: key ?? UniqueKey());
 
   static StoryVideo url(String url,
       {StoryController controller,
+      bool isHLS,
       Map<String, dynamic> requestHeaders,
       Key key}) {
     return StoryVideo(
       VideoLoader(url, requestHeaders: requestHeaders),
       storyController: controller,
       key: key,
+      isHLS: isHLS
     );
   }
 
@@ -79,13 +82,20 @@ class StoryVideoState extends State<StoryVideo> {
 
     widget.videoLoader.loadVideo(() {
       if (widget.videoLoader.state == LoadState.success) {
-        this.playerController =
-            VideoPlayerController.file(widget.videoLoader.videoFile);
+        /// if video is HLS, need to load it from network, if is a downloaded file, need to load it from local cache
+        if (widget.isHLS){
+          this.playerController =
+              VideoPlayerController.network(widget.videoLoader.url);
+        } else {
+          this.playerController =
+              VideoPlayerController.file(widget.videoLoader.videoFile);
 
-        playerController.initialize().then((v) {
+        }
+        this.playerController.initialize().then((v) {
           setState(() {});
           widget.storyController.play();
         });
+
 
         if (widget.storyController != null) {
           _streamSubscription =
@@ -114,7 +124,7 @@ class StoryVideoState extends State<StoryVideo> {
       );
     }
 
-    return widget.videoLoader.state == LoadState.loading
+    return widget.videoLoader.state == LoadState.loading || !playerController.value.initialized
         ? Center(
             child: Container(
               width: 70,

--- a/lib/widgets/story_view.dart
+++ b/lib/widgets/story_view.dart
@@ -218,6 +218,7 @@ class StoryItem {
     BoxFit imageFit = BoxFit.fitWidth,
     String caption,
     bool shown = false,
+    bool isHLS = false,
     Map<String, dynamic> requestHeaders,
   }) {
     return StoryItem(
@@ -228,6 +229,7 @@ class StoryItem {
               StoryVideo.url(
                 url,
                 controller: controller,
+                isHLS: isHLS,
                 requestHeaders: requestHeaders,
               ),
               SafeArea(


### PR DESCRIPTION
Hi,
For a client's projet, I needed to support HLS video urls (streaming) and not only video url downloaded on device cache. 
To use this feature, just fill url property with an HLS url and use **isHLS** boolean property to true