### PR TITLE
Fix Error if playerController has not been loaded and is null

### DIFF
--- a/lib/widgets/story_video.dart
+++ b/lib/widgets/story_video.dart
@@ -146,7 +146,7 @@ class StoryVideoState extends State<StoryVideo> {
 
   @override
   void dispose() {
-    playerController.dispose();
+    playerController?.dispose();
     _streamSubscription?.cancel();
     super.dispose();
   }


### PR DESCRIPTION
Avoid to call dispose if null value for player controller