### PR TITLE
Story controller hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,26 @@ Widget build(context) {
 }
 ```
 
+### Now with support to HookWidget 
+
+Using the hook `useStoryController` you don't have to worry about (or forgot) calling the dispose method for the controller and is now able to use it inside a `HookWidget`.
+
+```dart
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+class StoriesPage extends HookWidget {
+  @override
+  Widget build(BuildContext context) {
+    final StoryController controller = useStoryController();
+    return Material(
+       type: MaterialType.transparency,
+       child: StoryView(
+         storyItems: buildStoryItems(),
+         controller: controller,
+       ),
+     );
+   }
+}
+```
+
 🍭 Now, tell your users some stories.

--- a/example/example_hook.dart
+++ b/example/example_hook.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:story_view/hooks/use_story_controller.dart';
+import 'package:story_view/story_view.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+/// An example using the [StoryController] hook inside a [HookWidget]
+void main() => runApp(MyApp());
+
+class MyApp extends StatelessWidget {
+  // This widget is the root of your application.
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+        title: 'Flutter Demo',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(
+          primarySwatch: Colors.green,
+        ),
+        home: Home());
+  }
+}
+
+class Home extends HookWidget {
+  final StoryController controller = useStoryController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Delicious Ghanaian Meals"),
+      ),
+      body: Container(
+        margin: EdgeInsets.all(
+          8,
+        ),
+        child: ListView(
+          children: <Widget>[
+            Container(
+              height: 300,
+              child: StoryView(
+                controller: controller,
+                storyItems: [
+                  StoryItem.text(
+                    title:
+                        "Hello world!\nHave a look at some great Ghanaian delicacies. I'm sorry if your mouth waters. \n\nTap!",
+                    backgroundColor: Colors.orange,
+                    roundedTop: true,
+                  ),
+                  // StoryItem.inlineImage(
+                  //   NetworkImage(
+                  //       "https://image.ibb.co/gCZFbx/Banku-and-tilapia.jpg"),
+                  //   caption: Text(
+                  //     "Banku & Tilapia. The food to keep you charged whole day.\n#1 Local food.",
+                  //     style: TextStyle(
+                  //       color: Colors.white,
+                  //       backgroundColor: Colors.black54,
+                  //       fontSize: 17,
+                  //     ),
+                  //   ),
+                  // ),
+                  StoryItem.inlineImage(
+                    url:
+                        "https://image.ibb.co/cU4WGx/Omotuo-Groundnut-Soup-braperucci-com-1.jpg",
+                    controller: controller,
+                    caption: Text(
+                      "Omotuo & Nkatekwan; You will love this meal if taken as supper.",
+                      style: TextStyle(
+                        color: Colors.white,
+                        backgroundColor: Colors.black54,
+                        fontSize: 17,
+                      ),
+                    ),
+                  ),
+                  StoryItem.inlineImage(
+                    url:
+                        "https://media.giphy.com/media/5GoVLqeAOo6PK/giphy.gif",
+                    controller: controller,
+                    caption: Text(
+                      "Hektas, sektas and skatad",
+                      style: TextStyle(
+                        color: Colors.white,
+                        backgroundColor: Colors.black54,
+                        fontSize: 17,
+                      ),
+                    ),
+                  )
+                ],
+                onStoryShow: (s) {
+                  print("Showing a story");
+                },
+                onComplete: () {
+                  print("Completed a cycle");
+                },
+                progressPosition: ProgressPosition.bottom,
+                repeat: false,
+                inline: true,
+              ),
+            ),
+            Material(
+              child: InkWell(
+                onTap: () {
+                  Navigator.of(context).push(
+                      MaterialPageRoute(builder: (context) => MoreStories()));
+                },
+                child: Container(
+                  decoration: BoxDecoration(
+                      color: Colors.black54,
+                      borderRadius:
+                          BorderRadius.vertical(bottom: Radius.circular(8))),
+                  padding: EdgeInsets.symmetric(vertical: 8),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Icon(
+                        Icons.arrow_forward,
+                        color: Colors.white,
+                      ),
+                      SizedBox(
+                        width: 16,
+                      ),
+                      Text(
+                        "View more stories",
+                        style: TextStyle(fontSize: 16, color: Colors.white),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class MoreStories extends StatefulWidget {
+  @override
+  _MoreStoriesState createState() => _MoreStoriesState();
+}
+
+class _MoreStoriesState extends State<MoreStories> {
+  final storyController = StoryController();
+
+  @override
+  void dispose() {
+    storyController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("More"),
+      ),
+      body: StoryView(
+        storyItems: [
+          StoryItem.text(
+            title: "I guess you'd love to see more of our food. That's great.",
+            backgroundColor: Colors.blue,
+          ),
+          StoryItem.text(
+            title: "Nice!\n\nTap to continue.",
+            backgroundColor: Colors.red,
+            textStyle: TextStyle(
+              fontFamily: 'Dancing',
+              fontSize: 40,
+            ),
+          ),
+          StoryItem.pageImage(
+            url:
+                "https://image.ibb.co/cU4WGx/Omotuo-Groundnut-Soup-braperucci-com-1.jpg",
+            caption: "Still sampling",
+            controller: storyController,
+          ),
+          StoryItem.pageImage(
+              url: "https://media.giphy.com/media/5GoVLqeAOo6PK/giphy.gif",
+              caption: "Working with gifs",
+              controller: storyController),
+          StoryItem.pageImage(
+            url: "https://media.giphy.com/media/XcA8krYsrEAYXKf4UQ/giphy.gif",
+            caption: "Hello, from the other side",
+            controller: storyController,
+          ),
+          StoryItem.pageImage(
+            url: "https://media.giphy.com/media/XcA8krYsrEAYXKf4UQ/giphy.gif",
+            caption: "Hello, from the other side2",
+            controller: storyController,
+          ),
+        ],
+        onStoryShow: (s) {
+          print("Showing a story");
+        },
+        onComplete: () {
+          print("Completed a cycle");
+        },
+        progressPosition: ProgressPosition.top,
+        repeat: false,
+        controller: storyController,
+      ),
+    );
+  }
+}

--- a/lib/hooks/use_story_controller.dart
+++ b/lib/hooks/use_story_controller.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:story_view/controller/story_controller.dart';
+
+/// A hook for [StoryController] to let it be used by a [HookWidget]
+/// Provides the init and dispose methods.
+///
+/// Example:
+///
+/// ```
+/// import 'package:flutter_hooks/flutter_hooks.dart';
+///
+/// class StoriesPage extends HookWidget {
+///   @override
+///   Widget build(BuildContext context) {
+///     final controller = useStoryController();
+///     return Material(
+///        type: MaterialType.transparency,
+///        child: StoryView(
+///          storyItems: buildStoryItems(),
+///          controller: controller,
+///        ),
+///      );
+///    }
+/// }
+/// ```
+StoryController useStoryController() {
+  return use(const _UseStoryControllerHook());
+}
+
+class _UseStoryControllerHook extends Hook<StoryController> {
+  const _UseStoryControllerHook();
+
+  @override
+  _UseStoryControllerHookState createState() => _UseStoryControllerHookState();
+}
+
+class _UseStoryControllerHookState extends HookState<StoryController, _UseStoryControllerHook> {
+  late StoryController _storyController;
+
+  @override
+  void initHook() {
+    _storyController = StoryController();
+  }
+
+  @override
+  void dispose() {
+    _storyController.dispose();
+  }
+
+  @override
+  StoryController build(BuildContext context) => _storyController;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,6 +90,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
+  flutter_hooks:
+    dependency: "direct main"
+    description:
+      name: flutter_hooks
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.13.1
 homepage: https://github.com/blackmann/story_view
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -13,6 +13,7 @@ dependencies:
   rxdart: ^0.26.0
   video_player: ^2.0.0
   collection: ^1.15.0
+  flutter_hooks: ^0.17.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
There is a `StoryController` hook to be used by `HookWidget`s: useStoryController.

Example added.
README updated.

Using the hook `useStoryController` you don't have to worry about (or forgot) calling the dispose method for the controller and is now able to use it inside a `HookWidget`.

```dart
import 'package:flutter_hooks/flutter_hooks.dart';

class StoriesPage extends HookWidget {
  @override
  Widget build(BuildContext context) {
    final StoryController controller = useStoryController();
    return Material(
       type: MaterialType.transparency,
       child: StoryView(
         storyItems: buildStoryItems(),
         controller: controller,
       ),
     );
   }
}
```