### PR TITLE
Display black screen when switching between cached videos

### DIFF
--- a/lib/widgets/story_video.dart
+++ b/lib/widgets/story_video.dart
@@ -104,14 +104,17 @@ class StoryVideoState extends State<StoryVideo> {
   }
 
   Widget getContentView() {
-    if (widget.videoLoader.state == LoadState.success &&
-        playerController!.value.isInitialized) {
-      return Center(
-        child: AspectRatio(
-          aspectRatio: playerController!.value.aspectRatio,
-          child: VideoPlayer(playerController!),
-        ),
-      );
+    if (widget.videoLoader.state == LoadState.success) {
+      if (playerController!.value.isInitialized) {
+        return Center(
+          child: AspectRatio(
+            aspectRatio: playerController!.value.aspectRatio,
+            child: VideoPlayer(playerController!),
+          ),
+        );
+      } else {
+        return Container();
+      }
     }
 
     return widget.videoLoader.state == LoadState.loading


### PR DESCRIPTION
In reference to #103, StoryVideo now returns an empty Container which shows the user a black screen between video loads inspired by how Instagram switches between stories.