### PR TITLE
Remove redundant null-aware operator

### DIFF
--- a/lib/widgets/story_image.dart
+++ b/lib/widgets/story_image.dart
@@ -46,7 +46,7 @@ class ImageLoader {
 
         this.state = LoadState.success;
 
-        PaintingBinding.instance!.instantiateImageCodec(imageBytes).then(
+        PaintingBinding.instance.instantiateImageCodec(imageBytes).then(
             (codec) {
           this.frames = codec;
           onComplete();


### PR DESCRIPTION
Here is the fix for the new warning raised after upgrading to flutter 3.

The console message that was fixed:
```bash
Warning: Operand of null-aware operation '!' has type 'PaintingBinding' which excludes null.
```
