### PR TITLE
Use FractionallySizedBox to set width to half of parent

### DIFF
--- a/lib/widgets/story_view.dart
+++ b/lib/widgets/story_view.dart
@@ -707,11 +707,11 @@ class StoryViewState extends State<StoryView> with TickerProviderStateMixin {
           Align(
             alignment: Alignment.centerLeft,
             heightFactor: 1,
-            child: SizedBox(
+            child: FractionallySizedBox(
                 child: GestureDetector(onTap: () {
                   widget.controller.previous();
                 }),
-                width: 70),
+                widthFactor: 0.5),
           ),
         ],
       ),


### PR DESCRIPTION
<img width="384" alt="Screenshot 2022-10-27 at 6 53 10 PM" src="https://user-images.githubusercontent.com/62279469/198268247-0169d12a-180e-4617-a3f2-16520aa12432.png">

Current issue: Width of GestureDetector is not exactly half of the parent. Issue caused by the fix width set using `SizedBox` at 70px.

Fix: To use `FractionallySizedBox` to set widthFactor as half. Tested on both iOS and Redmi (Android) device.