### PR TITLE
Fix "The method 'instantiateImageCodec' isn't defined for the type 'PaintingBinding'"

### DIFF
--- a/lib/widgets/story_image.dart
+++ b/lib/widgets/story_image.dart
@@ -46,8 +46,7 @@ class ImageLoader {
 
         this.state = LoadState.success;
 
-        PaintingBinding.instance!.instantiateImageCodec(imageBytes).then(
-            (codec) {
+        ui.instantiateImageCodec(imageBytes).then((codec) {
           this.frames = codec;
           onComplete();
         }, onError: (error) {

--- a/lib/widgets/story_video.dart
+++ b/lib/widgets/story_video.dart
@@ -127,7 +127,7 @@ class StoryVideoState extends State<StoryVideo> {
           )
         : Center(
             child: Text(
-            "",
+            "Media failed to load.",
             style: TextStyle(
               color: Colors.white,
             ),

--- a/lib/widgets/story_video.dart
+++ b/lib/widgets/story_video.dart
@@ -127,7 +127,7 @@ class StoryVideoState extends State<StoryVideo> {
           )
         : Center(
             child: Text(
-            "Media failed to load.",
+            "",
             style: TextStyle(
               color: Colors.white,
             ),


### PR DESCRIPTION
Fixes "The method 'instantiateImageCodec' isn't defined for the type 'PaintingBinding'."

See it failing on pub.dev: https://pub.dev/packages/story_view/score