### PR TITLE
Video replay stuck on _goBack() fixed

### DIFF
--- a/lib/widgets/story_video.dart
+++ b/lib/widgets/story_video.dart
@@ -101,6 +101,10 @@ class StoryVideoState extends State<StoryVideo> {
         if (widget.storyController != null) {
           _streamSubscription =
               widget.storyController!.playbackNotifier.listen((playbackState) {
+            if (playbackState == PlaybackState.previous) {
+              playerController!.seekTo(Duration(seconds: 0));
+            }
+            
             if (playbackState == PlaybackState.pause) {
               playerController!.pause();
             } else {


### PR DESCRIPTION
Video used to contiue playing even when the user taps on previous (left side of story). This was a major bug need to be fixed.
I've added some lines to fix it and works like charm